### PR TITLE
Expose static `Prediction.wait(for:with:priority:retrier:)` method

### DIFF
--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -107,7 +107,7 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
     public static func wait(
         for current: Self,
         with client: Client,
-        priority: TaskPriority?,
+        priority: TaskPriority? = nil,
         retrier: inout Client.RetryPolicy.Iterator
     ) async throws -> Self {
         guard !current.status.terminated else { return current }

--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -94,7 +94,16 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
                                    retrier: &retrier)
     }
 
-    private static func wait(
+    /// Waits for a prediction to complete and returns the updated prediction.
+    ///
+    /// - Parameters:
+    ///     - current: The prediction to wait for.
+    ///     - client: The client used to make API requests.
+    ///     - priority: The task priority.
+    ///     - retrier: The retrier used to determine when to retry.
+    /// - Returns: The updated prediction.
+    /// - Throws: ``CancellationError`` if the prediction was canceled.
+    public static func wait(
         for current: Self,
         with client: Client,
         priority: TaskPriority?,

--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -88,7 +88,7 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
         with client: Client,
         priority: TaskPriority? = nil
     ) async throws {
-        var retrier = client.retryPolicy.makeIterator()
+        var retrier: Client.RetryPolicy.Retrier = client.retryPolicy.makeIterator()
         self = try await Self.wait(for: self,
                                    with: client,
                                    priority: priority,
@@ -101,7 +101,7 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
     ///     - current: The prediction to wait for.
     ///     - client: The client used to make API requests.
     ///     - priority: The task priority.
-    ///     - retrier: The retrier used to determine when to retry.
+    ///     - retrier: An instance of the client retry policy.
     /// - Returns: The updated prediction.
     /// - Throws: ``CancellationError`` if the prediction was canceled.
     public static func wait(

--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -83,6 +83,7 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
     ///     - maximumRetries: If specified,
     ///                       the maximum number of requests to make to the API
     ///                       before throwing ``CancellationError``.
+    /// - Throws: ``CancellationError`` if the prediction was canceled.
     public mutating func wait(
         with client: Client,
         priority: TaskPriority? = nil


### PR DESCRIPTION
Related to #37 

This PR exposes the currently private static `Prediction.wait(for:with:priority:retrier:)` method. Having a non-mutating method like this can be helpful for working around actor isolation issues in SwiftUI.