### PR TITLE
Add `urls` property to `Prediction` and `Training` model

### DIFF
--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -1,5 +1,6 @@
 import struct Foundation.Date
 import struct Foundation.TimeInterval
+import struct Foundation.URL
 import struct Dispatch.DispatchTime
 
 /// A prediction with unspecified inputs and outputs.
@@ -68,6 +69,9 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
 
     /// When the prediction was completed.
     public let completedAt: Date?
+
+    /// A convenience object that can be used to construct new API requests against the given prediction.
+    public let urls: [String: URL]
 
     // MARK: -
 
@@ -167,6 +171,7 @@ extension Prediction: Codable {
         case metrics
         case createdAt = "created_at"
         case completedAt = "completed_at"
+        case urls
     }
 }
 

--- a/Sources/Replicate/Training.swift
+++ b/Sources/Replicate/Training.swift
@@ -75,6 +75,9 @@ public struct Training<Input>: Identifiable where Input: Codable {
     /// When the training was completed.
     public let completedAt: Date?
 
+    /// A convenience object that can be used to construct new API requests against the given training.
+    public let urls: [String: URL]
+
     // MARK: -
 
     /// Cancel the training.
@@ -101,6 +104,7 @@ extension Training: Codable {
         case metrics
         case createdAt = "created_at"
         case completedAt = "completed_at"
+        case urls
     }
 }
 

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -121,6 +121,7 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(training.source, .web)
         XCTAssertEqual(training.status, .succeeded)
         XCTAssertEqual(training.createdAt.timeIntervalSinceReferenceDate, 703980786.224, accuracy: 1)
+        XCTAssertEqual(training.urls["cancel"]?.absoluteString, "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel")
     }
 
     func testCancelTraining() async throws {

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -54,6 +54,7 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(prediction.source, .web)
         XCTAssertEqual(prediction.status, .succeeded)
         XCTAssertEqual(prediction.createdAt.timeIntervalSinceReferenceDate, 672703986.224, accuracy: 1)
+        XCTAssertEqual(prediction.urls["cancel"]?.absoluteString, "https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel")
     }
 
     func testCancelPrediction() async throws {

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -445,8 +445,8 @@ class MockURLProtocol: URLProtocol {
                           "id": "zz4ibbonubfz7carwiefibzgga",
                           "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
                           "urls": {
-                            "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
-                            "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                            "get": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga",
+                            "cancel": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel"
                           },
                           "created_at": "2022-04-26T22:13:06.224088Z",
                           "completed_at": "2022-04-26T22:13:06.580379Z",
@@ -471,8 +471,8 @@ class MockURLProtocol: URLProtocol {
                       "id": "zz4ibbonubfz7carwiefibzgga",
                       "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
                       "urls": {
-                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
-                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                        "get": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga",
+                        "cancel": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel"
                       },
                       "created_at": "2022-04-26T22:13:06.224088Z",
                       "completed_at": "2022-04-26T22:13:06.580379Z",
@@ -494,8 +494,8 @@ class MockURLProtocol: URLProtocol {
                       "id": "zz4ibbonubfz7carwiefibzgga",
                       "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
                       "urls": {
-                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
-                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                        "get": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga",
+                        "cancel": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel"
                       },
                       "created_at": "2023-04-23T22:13:06.224088Z",
                       "completed_at": "2023-04-23T22:15:06.224088Z",
@@ -520,8 +520,8 @@ class MockURLProtocol: URLProtocol {
                       "id": "zz4ibbonubfz7carwiefibzgga",
                       "version": "4a056052b8b98f6db8d011a450abbcd09a408ec9280c29f22d3538af1099646a",
                       "urls": {
-                        "get": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq",
-                        "cancel": "https://api.replicate.com/v1/trainings/ufawqhfynnddngldkgtslldrkq/cancel"
+                        "get": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga",
+                        "cancel": "https://api.replicate.com/v1/trainings/zz4ibbonubfz7carwiefibzgga/cancel"
                       },
                       "created_at": "2023-04-23T22:13:06.224088Z",
                       "completed_at": "2023-04-23T22:15:06.224088Z",


### PR DESCRIPTION
Replicate's API provides a [`urls` field](https://replicate.com/docs/reference/http#predictions.get) in responses for predictions and trainings. This PR adds this property to the corresponding models.