### PR TITLE
Convert codable keys to snake case in Client fetch

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -401,7 +401,8 @@ public class Client {
             }
         case .post:
             if let params {
-                let encoder = JSONEncoder()
+                var encoder = JSONEncoder()
+                encoder.keyEncodingStrategy = .convertToSnakeCase
                 httpBody = try encoder.encode(params)
             }
         }

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -401,7 +401,7 @@ public class Client {
             }
         case .post:
             if let params {
-                var encoder = JSONEncoder()
+                let encoder = JSONEncoder()
                 encoder.keyEncodingStrategy = .convertToSnakeCase
                 httpBody = try encoder.encode(params)
             }


### PR DESCRIPTION
The Replicate HTTP API expects `snake_case` properties for JSON keys (e.g. `input.system_prompt`), which is uncommon in Swift. This change tells the JSON encoder to convert properties to `snake_case` during encoding for `POST`ing to the HTTP API.