### PR TITLE
Add `startedAt` property to `Prediction` and `Training`

### DIFF
--- a/Sources/Replicate/Prediction.swift
+++ b/Sources/Replicate/Prediction.swift
@@ -67,6 +67,9 @@ public struct Prediction<Input, Output>: Identifiable where Input: Codable, Outp
     /// When the prediction was created.
     public let createdAt: Date
 
+    /// When the prediction was started
+    public let startedAt: Date?
+
     /// When the prediction was completed.
     public let completedAt: Date?
 
@@ -170,6 +173,7 @@ extension Prediction: Codable {
         case logs
         case metrics
         case createdAt = "created_at"
+        case startedAt = "started_at"
         case completedAt = "completed_at"
         case urls
     }

--- a/Sources/Replicate/Training.swift
+++ b/Sources/Replicate/Training.swift
@@ -72,6 +72,9 @@ public struct Training<Input>: Identifiable where Input: Codable {
     /// When the training was created.
     public let createdAt: Date
 
+    /// When the training was started
+    public let startedAt: Date?
+
     /// When the training was completed.
     public let completedAt: Date?
 
@@ -103,6 +106,7 @@ extension Training: Codable {
         case logs
         case metrics
         case createdAt = "created_at"
+        case startedAt = "started_at"
         case completedAt = "completed_at"
         case urls
     }


### PR DESCRIPTION
The `startedAt` property describes when a prediction left the queue and started running.

See https://replicate.com/docs/reference/http