### PR TITLE
Use non-deprecated `createPrediction` method

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -72,11 +72,11 @@ public class Client {
         webhook: Webhook? = nil,
         _ type: Output.Type = Value.self
     ) async throws -> Output? {
-        let prediction = try await createPrediction(Prediction<Input, Output>.self,
+        var prediction = try await createPrediction(Prediction<Input, Output>.self,
                                                     version: identifier.version,
                                                     input: input,
-                                                    webhook: webhook,
-                                                    wait: true)
+                                                    webhook: webhook)
+        try await prediction.wait(with: self)
 
         if prediction.status == .failed {
             throw prediction.error ?? Error(detail: "Prediction failed")

--- a/Sources/Replicate/Predictable.swift
+++ b/Sources/Replicate/Predictable.swift
@@ -38,10 +38,12 @@ extension Predictable {
         webhook: Webhook? = nil,
         wait: Bool = false
     ) async throws -> Prediction {
-        return try await client.createPrediction(Prediction.self,
-                                                 version: Self.versionID,
-                                                 input: input,
-                                                 webhook: webhook,
-                                                 wait: wait)
+        var prediction =  try await client.createPrediction(Prediction.self,
+                                                            version: Self.versionID,
+                                                            input: input,
+                                                            webhook: webhook)
+        try await prediction.wait(with: client)
+
+        return prediction
     }
 }

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -41,7 +41,8 @@ final class ClientTests: XCTestCase {
 
     func testCreatePredictionAndWait() async throws {
         let version: Model.Version.ID = "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa"
-        let prediction = try await client.createPrediction(version: version, input: ["text": "Alice"], wait: true)
+        var prediction = try await client.createPrediction(version: version, input: ["text": "Alice"])
+        try await prediction.wait(with: client)
         XCTAssertEqual(prediction.id, "ufawqhfynnddngldkgtslldrkq")
         XCTAssertEqual(prediction.versionID, version)
         XCTAssertEqual(prediction.status, .succeeded)


### PR DESCRIPTION
Follow-up to #41 

This PR replaces use of the deprecated `createPrediction` method with `wait:` parameter in other methods in the package.