### PR TITLE
Use 'wait' argument on Predictable.predict

### DIFF
--- a/Sources/Replicate/Predictable.swift
+++ b/Sources/Replicate/Predictable.swift
@@ -42,7 +42,10 @@ extension Predictable {
                                                             version: Self.versionID,
                                                             input: input,
                                                             webhook: webhook)
-        try await prediction.wait(with: client)
+
+        if wait {
+            try await prediction.wait(with: client)
+        }
 
         return prediction
     }


### PR DESCRIPTION
`wait` argument on Predictable.predict is not used. This PR adds a conditional to .wait.
