### PR TITLE
Decrease min iOS version to v13

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -7,7 +7,7 @@ let package = Package(
     name: "Replicate",
     platforms: [
         .macOS(.v12),
-        .iOS(.v15)
+        .iOS(.v13)
     ],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ To learn how to use it, [take a look at our guide to building a SwiftUI app with
 
 ## Requirements
 
-- macOS 12+ or iOS 15+
+- macOS 12+ or iOS 13+
 - Swift 5.7
 
 ## Usage


### PR DESCRIPTION
Min iOS version could be decreased to iOS 13, package keeps compiling, unit tests successfully passing.