### PR TITLE
Don't set Authorization header unless API token is provided

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -527,7 +527,10 @@ public class Client {
 
         var request = URLRequest(url: url)
         request.httpMethod = method.rawValue
-        request.addValue("Token \(token)", forHTTPHeaderField: "Authorization")
+
+        if !token.isEmpty {
+            request.addValue("Token \(token)", forHTTPHeaderField: "Authorization")
+        }
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 
         if let httpBody {

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -159,6 +159,19 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(collection.slug, "super-resolution")
     }
 
+    func testInvalidToken() async throws {
+        do {
+            let _ = try await Client.invalid.listPredictions()
+            XCTFail("unauthenticated requests should fail")
+        } catch {
+            guard let error = error as? Replicate.Error else {
+                return XCTFail("invalid error")
+            }
+
+            XCTAssertEqual(error.detail, "Invalid token.")
+        }
+    }
+
     func testUnauthenticated() async throws {
         do {
             let _ = try await Client.unauthenticated.listPredictions()
@@ -168,7 +181,7 @@ final class ClientTests: XCTestCase {
                 return XCTFail("invalid error")
             }
 
-            XCTAssertEqual(error.detail, "Invalid token.")
+            XCTAssertEqual(error.detail, "Authentication credentials were not provided.")
         }
     }
 }

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -655,6 +655,10 @@ extension Client {
         return Client(token: MockURLProtocol.validToken).mocked
     }
 
+    static var invalid: Client {
+        return Client(token: "<invalid>").mocked
+    }
+
     static var unauthenticated: Client {
         return Client(token: "").mocked
     }


### PR DESCRIPTION
Sending a blank token results in requests having an `Authorization: Token ` header, to which Replicate's API responds with a 422 error instead of a 401. This PR prevents empty tokens from being sent, so that the client receives the more instructive server error.