### PR TITLE
Add support for `models.create` and `hardware.list` endpoints

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -479,6 +479,13 @@ public class Client {
         return try await fetch(.post, "trainings/\(id)/cancel")
     }
 
+    /// List hardware available for running a model on Replicate.
+    ///
+    /// - Returns: An array of hardware.
+    public func listHardware() async throws -> [Hardware] {
+        return try await fetch(.get, "hardware")
+    }
+
     // MARK: -
 
     private enum Method: String, Hashable {

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -486,6 +486,60 @@ public class Client {
         return try await fetch(.get, "hardware")
     }
 
+    /// Create a model
+    ///
+    /// - Parameters:
+    ///   - owner: The name of the user or organization that will own the model. This must be the same as the user or organization that is making the API request. In other words, the API token used in the request must belong to this user or organization.
+    ///   - name: The name of the model. This must be unique among all models owned by the user or organization.
+    ///   - visibility: Whether the model should be public or private. A public model can be viewed and run by anyone, whereas a private model can be viewed and run only by the user or organization members that own the model.
+    ///   - hardware: The SKU for the hardware used to run the model. Possible values can be found by calling ``listHardware()``.
+    ///   - description: A description of the model.
+    ///   - githubURL: A URL for the model's source code on GitHub.
+    ///   - paperURL: A URL for the model's paper.
+    ///   - licenseURL: A URL for the model's license.
+    ///   - coverImageURL: A URL for the model's cover image. This should be an image file.
+    public func createModel(
+        owner: String,
+        name: String,
+        visibility: Model.Visibility,
+        hardware: Hardware.ID,
+        description: String? = nil,
+        githubURL: URL? = nil,
+        paperURL: URL? = nil,
+        licenseURL: URL? = nil,
+        coverImageURL: URL? = nil
+    ) async throws -> Model
+    {
+        var params: [String: Value] = [
+            "owner": "\(owner)",
+            "name": "\(name)",
+            "visibility": "\(visibility.rawValue)",
+            "hardware": "\(hardware)"
+        ]
+
+        if let description {
+            params["description"] = "\(description)"
+        }
+
+        if let githubURL {
+            params["github_url"] = "\(githubURL)"
+        }
+
+        if let paperURL {
+            params["paper_url"] = "\(paperURL)"
+        }
+
+        if let licenseURL {
+            params["license_url"] = "\(licenseURL)"
+        }
+
+        if let coverImageURL {
+            params["cover_image_url"] = "\(coverImageURL)"
+        }
+
+        return try await fetch(.post, "models", params: params)
+    }
+
     // MARK: -
 
     private enum Method: String, Hashable {

--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -45,6 +45,8 @@ public class Client {
         self.token = token
     }
 
+    // MARK: -
+
     /// Runs a model and waits for its output.
     ///
     /// - Parameters:
@@ -84,6 +86,8 @@ public class Client {
 
         return prediction.output
     }
+
+    // MARK: -
 
     /// Create a prediction
     ///
@@ -296,6 +300,8 @@ public class Client {
         return try await fetch(.post, "predictions/\(id)/cancel")
     }
 
+    // MARK: -
+
     /// List public models
     /// - Parameters:
     ///     - Parameter cursor: A pointer to a page of results to fetch.
@@ -317,6 +323,72 @@ public class Client {
     {
         return try await fetch(.get, "models/\(id)")
     }
+
+    /// Create a model
+    ///
+    /// - Parameters:
+    ///   - owner: The name of the user or organization that will own the model. This must be the same as the user or organization that is making the API request. In other words, the API token used in the request must belong to this user or organization.
+    ///   - name: The name of the model. This must be unique among all models owned by the user or organization.
+    ///   - visibility: Whether the model should be public or private. A public model can be viewed and run by anyone, whereas a private model can be viewed and run only by the user or organization members that own the model.
+    ///   - hardware: The SKU for the hardware used to run the model. Possible values can be found by calling ``listHardware()``.
+    ///   - description: A description of the model.
+    ///   - githubURL: A URL for the model's source code on GitHub.
+    ///   - paperURL: A URL for the model's paper.
+    ///   - licenseURL: A URL for the model's license.
+    ///   - coverImageURL: A URL for the model's cover image. This should be an image file.
+    public func createModel(
+        owner: String,
+        name: String,
+        visibility: Model.Visibility,
+        hardware: Hardware.ID,
+        description: String? = nil,
+        githubURL: URL? = nil,
+        paperURL: URL? = nil,
+        licenseURL: URL? = nil,
+        coverImageURL: URL? = nil
+    ) async throws -> Model
+    {
+        var params: [String: Value] = [
+            "owner": "\(owner)",
+            "name": "\(name)",
+            "visibility": "\(visibility.rawValue)",
+            "hardware": "\(hardware)"
+        ]
+
+        if let description {
+            params["description"] = "\(description)"
+        }
+
+        if let githubURL {
+            params["github_url"] = "\(githubURL)"
+        }
+
+        if let paperURL {
+            params["paper_url"] = "\(paperURL)"
+        }
+
+        if let licenseURL {
+            params["license_url"] = "\(licenseURL)"
+        }
+
+        if let coverImageURL {
+            params["cover_image_url"] = "\(coverImageURL)"
+        }
+
+        return try await fetch(.post, "models", params: params)
+    }
+
+    // MARK: -
+
+    /// List hardware available for running a model on Replicate.
+    ///
+    /// - Returns: An array of hardware.
+    public func listHardware() async throws -> [Hardware] {
+        return try await fetch(.get, "hardware")
+    }
+
+
+    // MARK: -
 
     @available(*, deprecated, renamed: "listModelVersions(_:cursor:)")
     public func getModelVersions(_ id: Model.ID,
@@ -356,6 +428,8 @@ public class Client {
         return try await fetch(.get, "models/\(id)/versions/\(version)")
     }
 
+    // MARK: -
+
     /// List collections of models
     /// - Parameters:
     ///     - Parameter cursor: A pointer to a page of results to fetch.
@@ -378,6 +452,8 @@ public class Client {
     {
         return try await fetch(.get, "collections/\(slug)")
     }
+
+    // MARK: -
 
     /// Train a model on Replicate.
     ///
@@ -477,67 +553,6 @@ public class Client {
     ) async throws -> Training<Input>
     {
         return try await fetch(.post, "trainings/\(id)/cancel")
-    }
-
-    /// List hardware available for running a model on Replicate.
-    ///
-    /// - Returns: An array of hardware.
-    public func listHardware() async throws -> [Hardware] {
-        return try await fetch(.get, "hardware")
-    }
-
-    /// Create a model
-    ///
-    /// - Parameters:
-    ///   - owner: The name of the user or organization that will own the model. This must be the same as the user or organization that is making the API request. In other words, the API token used in the request must belong to this user or organization.
-    ///   - name: The name of the model. This must be unique among all models owned by the user or organization.
-    ///   - visibility: Whether the model should be public or private. A public model can be viewed and run by anyone, whereas a private model can be viewed and run only by the user or organization members that own the model.
-    ///   - hardware: The SKU for the hardware used to run the model. Possible values can be found by calling ``listHardware()``.
-    ///   - description: A description of the model.
-    ///   - githubURL: A URL for the model's source code on GitHub.
-    ///   - paperURL: A URL for the model's paper.
-    ///   - licenseURL: A URL for the model's license.
-    ///   - coverImageURL: A URL for the model's cover image. This should be an image file.
-    public func createModel(
-        owner: String,
-        name: String,
-        visibility: Model.Visibility,
-        hardware: Hardware.ID,
-        description: String? = nil,
-        githubURL: URL? = nil,
-        paperURL: URL? = nil,
-        licenseURL: URL? = nil,
-        coverImageURL: URL? = nil
-    ) async throws -> Model
-    {
-        var params: [String: Value] = [
-            "owner": "\(owner)",
-            "name": "\(name)",
-            "visibility": "\(visibility.rawValue)",
-            "hardware": "\(hardware)"
-        ]
-
-        if let description {
-            params["description"] = "\(description)"
-        }
-
-        if let githubURL {
-            params["github_url"] = "\(githubURL)"
-        }
-
-        if let paperURL {
-            params["paper_url"] = "\(paperURL)"
-        }
-
-        if let licenseURL {
-            params["license_url"] = "\(licenseURL)"
-        }
-
-        if let coverImageURL {
-            params["cover_image_url"] = "\(coverImageURL)"
-        }
-
-        return try await fetch(.post, "models", params: params)
     }
 
     // MARK: -

--- a/Sources/Replicate/Hardware.swift
+++ b/Sources/Replicate/Hardware.swift
@@ -1,0 +1,30 @@
+// Hardware for running a model on Replicate.
+public struct Hardware: Hashable, Codable {
+    public typealias ID = String
+
+    /// The product identifier for the hardware.
+    ///
+    /// For example, "gpu-a40-large".
+    public let sku: String
+
+    /// The name of the hardware.
+    ///
+    /// For example, "Nvidia A40 (Large) GPU".
+    public let name: String
+}
+
+// MARK: - Identifiable
+
+extension Hardware: Identifiable {
+    public var id: String {
+        return self.sku
+    }
+}
+
+// MARK: - CustomStringConvertible
+
+extension Hardware: CustomStringConvertible {
+    public var description: String {
+        return self.name
+    }
+}

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -153,6 +153,13 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(trainings.results.count, 1)
     }
 
+    func testListHardware() async throws {
+        let hardware = try await client.listHardware() 
+        XCTAssertGreaterThan(hardware.count, 1)
+        XCTAssertEqual(hardware.first?.name, "CPU")
+        XCTAssertEqual(hardware.first?.sku, "cpu")
+    }
+
     func testCustomBaseURL() async throws {
         let client = Client(baseURLString: "https://v1.replicate.proxy", token: MockURLProtocol.validToken).mocked
         let collection = try await client.getModelCollection("super-resolution")

--- a/Tests/ReplicateTests/ClientTests.swift
+++ b/Tests/ReplicateTests/ClientTests.swift
@@ -105,6 +105,12 @@ final class ClientTests: XCTestCase {
         XCTAssertEqual(version.id, "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa")
     }
 
+    func testCreateModel() async throws {
+        let model = try await client.createModel(owner: "replicate", name: "hello-world", visibility: .public, hardware: "cpu")
+        XCTAssertEqual(model.owner, "replicate")
+        XCTAssertEqual(model.name, "hello-world")
+    }
+
     func testListModelCollections() async throws {
         let collections = try await client.listModelCollections()
         XCTAssertEqual(collections.results.count, 1)

--- a/Tests/ReplicateTests/DateDecodingTests.swift
+++ b/Tests/ReplicateTests/DateDecodingTests.swift
@@ -23,6 +23,6 @@ final class DateDecodingTests: XCTestCase {
         let timestamp = "2023-10-29T01:23:45.678900Z"
         let json = #"{"date": "\#(timestamp)"}"#
         let value = try decoder.decode(Value.self, from: json.data(using: .utf8)!)
-        XCTAssertEqualWithAccuracy(value.date.timeIntervalSince1970, 1698542625.678, accuracy: 0.1)
+        XCTAssertEqual(value.date.timeIntervalSince1970, 1698542625.678, accuracy: 0.1)
     }
 }

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -165,10 +165,7 @@ class MockURLProtocol: URLProtocol {
                       { "name": "CPU", "sku": "cpu" },
                       { "name": "Nvidia T4 GPU", "sku": "gpu-t4" },
                       { "name": "Nvidia A40 GPU", "sku": "gpu-a40-small" },
-                      { "name": "Nvidia A40 (Large) GPU", "sku": "gpu-a40-large" },
-                      { "name": "Nvidia A40 (Large) GPU (8x)", "sku": "gpu-a40-large-8x" },
-                      { "name": "Nvidia A100 (40GB) GPU", "sku": "gpu-a100-small" },
-                      { "name": "Nvidia A100 (80GB) GPU", "sku": "gpu-a100-large" },
+                      { "name": "Nvidia A40 (Large) GPU", "sku": "gpu-a40-large" }
                     ]
                 """#
             case ("GET", "https://api.replicate.com/v1/models"?):

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -465,6 +465,23 @@ class MockURLProtocol: URLProtocol {
                       }
                     }
                 """#
+            case ("POST", "https://api.replicate.com/v1/models"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "url": "https://replicate.com/replicate/hello-world",
+                      "owner": "replicate",
+                      "name": "hello-world",
+                      "description": "A tiny model that says hello",
+                      "visibility": "public",
+                      "github_url": null,
+                      "paper_url": null,
+                      "license_url": null,
+                      "run_count": 0,
+                      "cover_image_url": null,
+                      "default_example": null
+                    }
+                """#
             case ("GET", "https://api.replicate.com/v1/models/replicate/hello-world/versions"?):
                 statusCode = 200
                 json = #"""

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -158,6 +158,19 @@ class MockURLProtocol: URLProtocol {
                       "metrics": {}
                     }
                 """#
+            case ("GET", "https://api.replicate.com/v1/hardware"?):
+                statusCode = 200
+                json = #"""
+                    [
+                      { "name": "CPU", "sku": "cpu" },
+                      { "name": "Nvidia T4 GPU", "sku": "gpu-t4" },
+                      { "name": "Nvidia A40 GPU", "sku": "gpu-a40-small" },
+                      { "name": "Nvidia A40 (Large) GPU", "sku": "gpu-a40-large" },
+                      { "name": "Nvidia A40 (Large) GPU (8x)", "sku": "gpu-a40-large-8x" },
+                      { "name": "Nvidia A100 (40GB) GPU", "sku": "gpu-a100-small" },
+                      { "name": "Nvidia A100 (80GB) GPU", "sku": "gpu-a100-large" },
+                    ]
+                """#
             case ("GET", "https://api.replicate.com/v1/models"?):
                 statusCode = 200
                 json = #"""


### PR DESCRIPTION
See https://replicate.com/docs/reference/http#models.create