### PR TITLE
Add `.spi.yml`

### DIFF
--- a/.spi.yml
+++ b/.spi.yml
@@ -1,0 +1,6 @@
+version: 1
+builder:
+  configs:
+    - documentation_targets: [Replicate]
+  metadata:
+    - authors: Replicate


### PR DESCRIPTION
From [Swift Package Index](https://swiftpackageindex.com/SwiftPackageIndex/SPIManifest/1.1.1/documentation/spimanifest/commonusecases):

> The contents of a .spi.yml file allow package authors to configure their package when indexed by the Swift Package Index.