### PR TITLE
Fix pagination for models

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -308,7 +308,7 @@ public class Client {
     public func listModels(cursor: Pagination.Cursor? = nil)
         async throws -> Pagination.Page<Model>
     {
-        return try await fetch(.get, "models")
+        return try await fetch(.get, "models", cursor: cursor)
     }
 
     /// Get a model


### PR DESCRIPTION
The `Client.listModels()` method doesn't pass the specified `cursor` parameter when fetching models. As a result, you can't enumerate beyond the initial page of results. This PR fixes this by passing the `cursor` parameter to the underlying `fetch` method.