### PR TITLE
Use Bearer authorization scheme

### DIFF
--- a/Sources/Replicate/Client.swift
+++ b/Sources/Replicate/Client.swift
@@ -683,7 +683,7 @@ public class Client {
         request.httpMethod = method.rawValue
 
         if !token.isEmpty {
-            request.addValue("Token \(token)", forHTTPHeaderField: "Authorization")
+            request.addValue("Bearer \(token)", forHTTPHeaderField: "Authorization")
         }
         request.addValue("application/json", forHTTPHeaderField: "Accept")
 

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -26,7 +26,7 @@ class MockURLProtocol: URLProtocol {
         let json: String
 
         switch request.value(forHTTPHeaderField: "Authorization") {
-        case "Token \(Self.validToken)":
+        case "Bearer \(Self.validToken)":
             switch (request.httpMethod, request.url?.absoluteString) {
             case ("GET", "https://api.replicate.com/v1/account"?):
                 statusCode = 200


### PR DESCRIPTION
Replicate's API now supports the standard [Bearer authentication scheme](https://swagger.io/docs/specification/authentication/bearer-authentication/). 

https://replicate.com/changelog/2024-04-03-bearer-tokens

For compatibility with existing clients, the existing `Token` scheme will be supported indefinitely. But going forward, the new `Bearer` scheme is preferred.