### PR TITLE
Add `updateHandler` callback for `Prediction.wait` and `Client.run` methods

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This is a Swift client for [Replicate].
 It lets you run models from your Swift code,
 and do various other things on Replicate.
 
-To learn how to use it, 
+To learn how to use it,
 [take a look at our guide to building a SwiftUI app with Replicate](https://replicate.com/docs/get-started/swiftui).
 
 ## Usage
@@ -32,7 +32,10 @@ You can run a model and get its output:
 let output = try await replicate.run(
     "stability-ai/stable-diffusion-3",
     ["prompt": "a 19th century portrait of a gentleman otter"]
-)
+) { prediction in
+    // Print the prediction status after each update
+    print(prediction.status)
+}
 
 print(output)
 // ["https://replicate.delivery/yhqm/bh9SsjWXY3pGKJyQzYjQlsZPzcNZ4EYOeEsPjFytc5TjYeNTA/R8_SD3_00001_.webp"]
@@ -59,7 +62,7 @@ like [tencentarc/gfpgan](https://replicate.com/tencentarc/gfpgan),
 receive images as inputs.
 To run a model that takes a file input you can pass either
 a URL to a publicly accessible file on the Internet
-or use the `uriEncoded(mimeType:) helper method to create 
+or use the `uriEncoded(mimeType:) helper method to create
 a base64-encoded data URL from the contents of a local file.
 
 ```swift

--- a/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
+++ b/Tests/ReplicateTests/Helpers/MockURLProtocol.swift
@@ -174,6 +174,32 @@ class MockURLProtocol: URLProtocol {
                       }
                     }
                 """#
+            case ("GET", "https://api.replicate.com/v1/predictions/r6bjfddngldkt2o3bzn3ahtaci"?):
+                statusCode = 200
+                json = #"""
+                    {
+                      "id": "r6bjfddngldkt2o3bzn3ahtaci",
+                      "model": "meta/llama-2-70b-chat",
+                      "version": "5c7d5dc6dd8bf75c1acaa8565735e7986bc5b66206b55cca93cb72c9bf15ccaa",
+                      "urls": {
+                        "get": "https://api.replicate.com/v1/predictions/heat2o3bzn3ahtr6bjfftvbaci",
+                        "cancel": "https://api.replicate.com/v1/predictions/heat2o3bzn3ahtr6bjfftvbaci/cancel"
+                      },
+                      "created_at": "2022-04-26T22:13:06.224088Z",
+                      "completed_at": "2022-04-26T22:15:06.224088Z",
+                      "source": "web",
+                      "status": "processing",
+                      "input": {
+                          "prompt": "Please write a haiku about llamas."
+                      },
+                      "output": null,
+                      "error": null,
+                      "logs": "",
+                      "metrics": {
+                        "predict_time": 1.0
+                      }
+                    }
+                """#
             case ("POST", "https://api.replicate.com/v1/predictions/ufawqhfynnddngldkgtslldrkq/cancel"?):
                 statusCode = 200
                 json = #"""


### PR DESCRIPTION
`updateHandler` is a closure that executes with the updated prediction after each polling request to the API. It can be passed as a trailing closure. You can use it to provide feedback to the user about the progress of the prediction, or throw `CancellationError` to stop waiting for the prediction to finish.

```swift
let output = try await replicate.run(
    "stability-ai/stable-diffusion-3",
    ["prompt": "a 19th century portrait of a gentleman otter"]
) { prediction in
    // Print the prediction status after each update
    print(prediction.status)
}
```

If the prediction is in a terminal state (e.g. `succeeded`, `failed`, or `canceled`), it's returned immediately and the closure is not executed. 